### PR TITLE
Fix Task Cell onMouseClick Bug

### DIFF
--- a/src/octillect/controls/TaskCell.java
+++ b/src/octillect/controls/TaskCell.java
@@ -171,8 +171,10 @@ public class TaskCell extends ListCell<Task> implements Injectable<ApplicationCo
         });
 
         setOnMouseClicked(event -> {
-            Column parentColumn = ((TasksColumn) (getListView().getParent().getParent())).getItem();
-            taskSettingsController.loadTask(getItem(), parentColumn);
+            if(event.getSource() instanceof TaskCell && getItem() != null) {
+                Column parentColumn = ((TasksColumn) (getListView().getParent().getParent())).getItem();
+                taskSettingsController.loadTask(getItem(), parentColumn);
+            }
         });
 
     }


### PR DESCRIPTION
 * Handle raising NullPointerException when clicking on an Empty cell
   within the TasksColumn's ListView.