### PR TITLE
Improve GitHub API Performance

### DIFF
--- a/src/octillect/controllers/BoardController.java
+++ b/src/octillect/controllers/BoardController.java
@@ -71,10 +71,6 @@ public class BoardController implements Injectable<ApplicationController> {
         titleBarController.boardNameLabel.setText(board.getName());
         boardSettingsController.loadBoardSettings();
 
-        if (currentBoard.getRepositoryName() != null) {
-            gitHubRepositoryController.loadGitHubRepository();
-        }
-
         // Populate Board Columns
         boardListView.setItems(board.getChildren());
         boardListView.setCellFactory(param -> {
@@ -88,6 +84,7 @@ public class BoardController implements Injectable<ApplicationController> {
     @FXML
     public void handleGitHubIconMouseClicked(MouseEvent mouseEvent) {
         if (currentBoard.getRepositoryName() != null) {
+            gitHubRepositoryController.loadGitHubRepository();
             rightDrawerController.show(rightDrawerController.gitHubRepository);
             applicationController.drawersStack.toggle(rightDrawerController.rightDrawer);
         } else {

--- a/src/octillect/controllers/dialogs/RepositoryNameDialogController.java
+++ b/src/octillect/controllers/dialogs/RepositoryNameDialogController.java
@@ -74,8 +74,11 @@ public class RepositoryNameDialogController implements Injectable<ApplicationCon
             boardController.currentBoard.setRepositoryName(repositoryNameTextField.getText());
             gitHubRepositoryController.loadGitHubRepository();
 
-            rightDrawerController.show(rightDrawerController.gitHubRepository);
-            applicationController.drawersStack.toggle(rightDrawerController.rightDrawer);
+            if (rightDrawerController.rightDrawer.isClosed()) {
+                // Prevent Drawer toggling if the drawer is already open
+                rightDrawerController.show(rightDrawerController.gitHubRepository);
+                applicationController.drawersStack.toggle(rightDrawerController.rightDrawer);
+            }
 
             repositoryNameDialog.close();
         }

--- a/src/octillect/controllers/settings/GitHubRepositoryController.java
+++ b/src/octillect/controllers/settings/GitHubRepositoryController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import javafx.fxml.FXML;
@@ -12,6 +13,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.image.Image;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.ImagePattern;
 
 import octillect.controllers.ApplicationController;
 import octillect.controllers.BoardController;
@@ -73,6 +75,8 @@ public class GitHubRepositoryController implements Injectable<ApplicationControl
                 int commitsLimit = 15;
                 List<GHCommit> commits = repository.listCommits()._iterator(commitsLimit).nextPage();
 
+                HashMap<String, ImagePattern> avatars = new HashMap<>();
+
                 for (GHCommit commit : commits) {
 
                     URI url   = commit.getHtmlUrl().toURI();
@@ -85,7 +89,14 @@ public class GitHubRepositoryController implements Injectable<ApplicationControl
 
                     String authorUsername  = commit.getAuthor().getLogin();
                     String authorAvatarUrl = commit.getAuthor().getAvatarUrl().replace("s=460", "s=128");
-                    Image authorAvatar     = new Image(authorAvatarUrl);
+
+                    ImagePattern authorAvatar;
+                    if (avatars.containsKey(authorAvatarUrl)) {
+                        authorAvatar = avatars.get(authorAvatarUrl);
+                    } else {
+                        authorAvatar = new ImagePattern(new Image(authorAvatarUrl));
+                        avatars.put(authorAvatarUrl, authorAvatar);
+                    }
 
                     Commit commitModel = new CommitBuilder().with($ -> {
                         $.url            = url;

--- a/src/octillect/controls/CommitCell.java
+++ b/src/octillect/controls/CommitCell.java
@@ -48,10 +48,10 @@ public class CommitCell extends ListCell<Commit> {
         String subject = commitItem.getSubject();
         subject = subject.length() <= 50 ? subject : subject.substring(0, 50) + "...";
 
-        SimpleDateFormat sdf = new SimpleDateFormat("d MMM yyyy, HH:mm");
+        SimpleDateFormat sdf = new SimpleDateFormat("d MMM yyyy, h:mm a");
         String date = sdf.format(commitItem.getDate());
 
-        authorAvatarCircle.setFill(new ImagePattern(commitItem.getAuthorAvatar()));
+        authorAvatarCircle.setFill(commitItem.getAuthorAvatar());
         subjectHyperlink.setText(subject);
         bodyLabel.setText(commitItem.getBody());
         authorUsernameLabel.setText(commitItem.getAuthorUsername());

--- a/src/octillect/models/Commit.java
+++ b/src/octillect/models/Commit.java
@@ -3,7 +3,7 @@ package octillect.models;
 import java.net.URI;
 import java.util.Date;
 
-import javafx.scene.image.Image;
+import javafx.scene.paint.ImagePattern;
 
 public class Commit {
 
@@ -11,10 +11,10 @@ public class Commit {
     private String subject;
     private String body;
     private String authorUsername;
-    private Image authorAvatar;
+    private ImagePattern authorAvatar;
     private Date date;
 
-    public Commit(URI url, String subject, String body, String authorUsername, Image authorAvatar, Date date) {
+    public Commit(URI url, String subject, String body, String authorUsername, ImagePattern authorAvatar, Date date) {
         this.url = url;
         this.subject = subject;
         this.body = body;
@@ -60,11 +60,11 @@ public class Commit {
     }
 
 
-    public Image getAuthorAvatar() {
+    public ImagePattern getAuthorAvatar() {
         return authorAvatar;
     }
 
-    public void setAuthorAvatar(Image authorAvatar) {
+    public void setAuthorAvatar(ImagePattern authorAvatar) {
         this.authorAvatar = authorAvatar;
     }
 

--- a/src/octillect/models/builders/CommitBuilder.java
+++ b/src/octillect/models/builders/CommitBuilder.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.util.Date;
 import java.util.function.Consumer;
 
-import javafx.scene.image.Image;
+import javafx.scene.paint.ImagePattern;
 
 import octillect.models.Commit;
 
@@ -14,7 +14,7 @@ public class CommitBuilder implements Builder<Commit, CommitBuilder> {
     public String subject;
     public String body;
     public String authorUsername;
-    public Image authorAvatar;
+    public ImagePattern authorAvatar;
     public Date date;
 
     @Override
@@ -49,7 +49,7 @@ public class CommitBuilder implements Builder<Commit, CommitBuilder> {
         return this;
     }
 
-    public CommitBuilder withAuthorAvatar(Image authorAvatar) {
+    public CommitBuilder withAuthorAvatar(ImagePattern authorAvatar) {
         this.authorAvatar = authorAvatar;
         return this;
     }


### PR DESCRIPTION
 * Use ImagePattern instead of Image in the commit model; to decrease conversion time.
 * Cache pre-loaded images in a hash map; to save memory and decrease URL accessing and converting to images.
 * Prevent drawer from closing after editing the name; to avoid loading duplication.
 * Load the repository commits only when the GitHub button is clicked; to keep the commits synchronized with GitHub's repository latest commits and minimize project's loading time.