### PR TITLE
Use Specific Types in Models' Constructors

### DIFF
--- a/src/octillect/controls/TaskCell.java
+++ b/src/octillect/controls/TaskCell.java
@@ -242,7 +242,7 @@ public class TaskCell extends ListCell<Task> implements Injectable<ApplicationCo
         taskNameLabel.setText(taskItem.getName());
 
         if (taskItem.getDueDate() == null && !taskItem.getIsCompleted()
-                && taskItem.getAssignees().isEmpty() && taskItem.getChildren().isEmpty()
+                && taskItem.getAssignees().isEmpty() && taskItem.<Task>getChildren().isEmpty()
                 && (taskItem.getDescription() == null || taskItem.getDescription().equals(""))) {
             taskCellVBox.getChildren().remove(taskInfoBorderPane);
         }

--- a/src/octillect/database/repositories/ColumnRepository.java
+++ b/src/octillect/database/repositories/ColumnRepository.java
@@ -10,7 +10,6 @@ import octillect.database.documents.ColumnDocument;
 import octillect.database.firebase.FirestoreAPI;
 import octillect.models.Column;
 import octillect.models.Task;
-import octillect.models.TaskBase;
 import octillect.models.builders.ColumnBuilder;
 
 public class ColumnRepository implements Repository<Column> {

--- a/src/octillect/database/repositories/TaskRepository.java
+++ b/src/octillect/database/repositories/TaskRepository.java
@@ -45,7 +45,7 @@ public class TaskRepository implements Repository<Task> {
 
         ArrayList<HashMap<String, String>> subTasks = new ArrayList<>();
         for (Task subTask : task.<Task>getChildren()) {
-            SubTaskMap subTaskMap = new SubTaskMap(subTask.getId(), subTask.getName(), ((Task) subTask).getIsCompleted());
+            SubTaskMap subTaskMap = new SubTaskMap(subTask.getId(), subTask.getName(), subTask.getIsCompleted());
             subTasks.add(subTaskMap.getMap());
         }
         document.setSubTasks(subTasks);

--- a/src/octillect/models/Board.java
+++ b/src/octillect/models/Board.java
@@ -23,12 +23,12 @@ public class Board extends TaskBase implements IObservable<Contributor> {
     }
 
     public Board(String id, String name, String description, String repositoryName,
-                 ObservableList<Contributor> contributors, ObservableList<TaskBase> columns,
+                 ObservableList<Contributor> contributors, ObservableList<Column> columns,
                  ObservableList<Tag> tags) {
         super(id, name, description, columns);
         this.repositoryName = repositoryName;
-        this.contributors = contributors;
-        this.tags = tags;
+        this.contributors   = contributors;
+        this.tags           = tags;
     }
 
 

--- a/src/octillect/models/Column.java
+++ b/src/octillect/models/Column.java
@@ -4,7 +4,7 @@ import javafx.collections.ObservableList;
 
 public class Column extends TaskBase {
 
-    public Column(String id, String name, ObservableList<TaskBase> tasks) {
+    public Column(String id, String name, ObservableList<Task> tasks) {
         super(id, name, null, tasks);
     }
 

--- a/src/octillect/models/Task.java
+++ b/src/octillect/models/Task.java
@@ -17,14 +17,14 @@ public class Task extends TaskBase {
 
     public Task(String id, String name, String description, boolean isCompleted,
                 Date dueDate, Date creationDate, Contributor creator, ObservableList<Contributor> assignees,
-                ObservableList<TaskBase> subTasks, ObservableList<Tag> tags) {
+                ObservableList<Task> subTasks, ObservableList<Tag> tags) {
         super(id, name, description, subTasks);
         this.isCompleted  = isCompleted;
         this.dueDate      = dueDate;
         this.creationDate = creationDate;
         this.creator      = creator;
         this.assignees    = assignees;
-        this.tags = tags;
+        this.tags         = tags;
     }
 
 

--- a/src/octillect/models/TaskBase.java
+++ b/src/octillect/models/TaskBase.java
@@ -14,11 +14,11 @@ abstract public class TaskBase {
     TaskBase() {
     }
 
-    TaskBase(String id, String name, String description, ObservableList<TaskBase> children) {
-        this.id = id;
-        this.name = name;
+    TaskBase(String id, String name, String description, ObservableList<? extends TaskBase> children) {
+        this.id          = id;
+        this.name        = name;
         this.description = description;
-        this.children = children;
+        this.children    = children;
     }
 
 

--- a/src/octillect/models/builders/BoardBuilder.java
+++ b/src/octillect/models/builders/BoardBuilder.java
@@ -14,7 +14,7 @@ public class BoardBuilder implements Builder<Board, BoardBuilder> {
     public String description;
     public String repositoryName;
     public ObservableList<Contributor> contributors = FXCollections.observableArrayList();
-    public ObservableList<TaskBase> columns = FXCollections.observableArrayList();
+    public ObservableList<Column> columns = FXCollections.observableArrayList();
     public ObservableList<Tag> tags = FXCollections.observableArrayList();
 
     @Override
@@ -53,7 +53,7 @@ public class BoardBuilder implements Builder<Board, BoardBuilder> {
         return this;
     }
 
-    public BoardBuilder withColumns(ObservableList<TaskBase> columns) {
+    public BoardBuilder withColumns(ObservableList<Column> columns) {
         this.columns = columns;
         return this;
     }

--- a/src/octillect/models/builders/ColumnBuilder.java
+++ b/src/octillect/models/builders/ColumnBuilder.java
@@ -6,13 +6,14 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import octillect.models.Column;
+import octillect.models.Task;
 import octillect.models.TaskBase;
 
 public class ColumnBuilder implements Builder<Column, ColumnBuilder> {
 
     public String id;
     public String name;
-    public ObservableList<TaskBase> tasks = FXCollections.observableArrayList();
+    public ObservableList<Task> tasks = FXCollections.observableArrayList();
 
     @Override
     public ColumnBuilder with(Consumer<ColumnBuilder> builderFunction) {
@@ -35,7 +36,7 @@ public class ColumnBuilder implements Builder<Column, ColumnBuilder> {
         return this;
     }
 
-    public ColumnBuilder withTasks(ObservableList<TaskBase> tasks) {
+    public ColumnBuilder withTasks(ObservableList<Task> tasks) {
         this.tasks = tasks;
         return this;
     }

--- a/src/octillect/models/builders/TaskBuilder.java
+++ b/src/octillect/models/builders/TaskBuilder.java
@@ -18,7 +18,7 @@ public class TaskBuilder implements Builder<Task, TaskBuilder> {
     public Date creationDate;
     public Contributor creator;
     public ObservableList<Contributor> assignees = FXCollections.observableArrayList();
-    public ObservableList<TaskBase> subTasks = FXCollections.observableArrayList();
+    public ObservableList<Task> subTasks = FXCollections.observableArrayList();
     public ObservableList<Tag> tags = FXCollections.observableArrayList();
 
     @Override
@@ -72,7 +72,7 @@ public class TaskBuilder implements Builder<Task, TaskBuilder> {
         return this;
     }
 
-    public TaskBuilder withSubTasks(ObservableList<TaskBase> subTasks) {
+    public TaskBuilder withSubTasks(ObservableList<Task> subTasks) {
         this.subTasks = subTasks;
         return this;
     }


### PR DESCRIPTION
 * Fix TaskBase's constructor to accept a generic ObservableList.
 * Apply Changes to Board, Column & Task Models and Builders.
 * Add missing type casting and remove unnecessary ones.