### PR TITLE
Fix ComboBox Style Sheet

### DIFF
--- a/src/octillect/styles/ComboBox.css
+++ b/src/octillect/styles/ComboBox.css
@@ -5,15 +5,6 @@
     -fx-text-fill: -o-dark-300;
 }
 
-.jfx-combo-box .text-field {
-    -fx-text-fill: -o-dark-300;
-}
-
-.jfx-combo-box .label {
-	-fx-background:  WHITE;
-	-fx-text-fill: -o-dark-300;
-}
-
 .combo-box-popup .list-cell {
     -fx-background-color: -o-dark-700;
     -fx-text-fill: -o-dark-300;


### PR DESCRIPTION
 * Reset Error Label color to **Red** instead of **White**.
 * Remove unnecessary pseudo-class.


| ![before](https://user-images.githubusercontent.com/41103290/58098561-237d1e00-7bda-11e9-8c7a-44480230a552.png) | ![after](https://user-images.githubusercontent.com/41103290/58098562-237d1e00-7bda-11e9-9717-3704702974f5.png) |
|:---------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------------------------------:|
| _before_                                                                                                          | _after_                                                                                                          |