### PR TITLE
Improve Internal Calls in Database Package

### DIFF
--- a/src/octillect/database/firebase/FirestoreAPI.java
+++ b/src/octillect/database/firebase/FirestoreAPI.java
@@ -15,11 +15,11 @@ import java.util.concurrent.ExecutionException;
 public class FirestoreAPI {
 
     // Collections' names constants
-    public final String USERS    = "users";
-    public final String BOARDS   = "boards";
-    public final String TASKS    = "tasks";
-    public final String TAGS     = "tags";
-    public final String COLUMNS  = "columns";
+    public final static String USERS    = "users";
+    public final static String BOARDS   = "boards";
+    public final static String TASKS    = "tasks";
+    public final static String TAGS     = "tags";
+    public final static String COLUMNS  = "columns";
 
     private static FirestoreAPI ourInstance = new FirestoreAPI();
 
@@ -31,7 +31,7 @@ public class FirestoreAPI {
     }
 
     // Select a whole document
-    public Object selectDocument(String collection, String document) {
+    public DocumentSnapshot selectDocument(String collection, String document) {
         DocumentReference docRef = Connection.getInstance().firestore.collection(collection).document(document);
         ApiFuture<DocumentSnapshot> documentSnapshot = docRef.get();
         try {

--- a/src/octillect/database/firebase/StorageAPI.java
+++ b/src/octillect/database/firebase/StorageAPI.java
@@ -16,9 +16,9 @@ import javax.imageio.ImageIO;
 
 public class StorageAPI {
 
-    public final String USER_PHOTOS_FOLDER       = "userPhotos/";
-    public final String IMAGE_ATTACHMENTS_FOLDER = "imageAttachments/";
-    private StorageClient storageClient          = StorageClient.getInstance();
+    public final static String USER_PHOTOS_FOLDER       = "userPhotos/";
+    public final static String IMAGE_ATTACHMENTS_FOLDER = "imageAttachments/";
+    private StorageClient storageClient                 = StorageClient.getInstance();
 
     private static StorageAPI ourInstance = new StorageAPI();
 

--- a/src/octillect/database/repositories/BoardRepository.java
+++ b/src/octillect/database/repositories/BoardRepository.java
@@ -1,7 +1,5 @@
 package octillect.database.repositories;
 
-import com.google.cloud.firestore.DocumentSnapshot;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -54,13 +52,13 @@ public class BoardRepository implements Repository<Board> {
         }
         document.setTagsIds(tagsIds);
 
-        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.getInstance().BOARDS, document.getId(), document);
+        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.BOARDS, document.getId(), document);
     }
 
     @Override
     public Board get(String boardId) {
 
-        BoardDocument document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().BOARDS, boardId)).toObject(BoardDocument.class);
+        BoardDocument document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.BOARDS, boardId).toObject(BoardDocument.class);
 
         Board board = new BoardBuilder().with($ -> {
             $.id = document.getId();
@@ -95,13 +93,13 @@ public class BoardRepository implements Repository<Board> {
 
     @Override
     public void delete(Board board) {
-        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().BOARDS, board.getId());
+        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.BOARDS, board.getId());
 
         for (Column column : board.<Column>getChildren()) {
             for (Task task : column.<Task>getChildren()) {
-                FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().TASKS, task.getId());
+                FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.TASKS, task.getId());
             }
-            FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().COLUMNS, column.getId());
+            FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.COLUMNS, column.getId());
         }
         for (Tag tag : board.getTags()) {
             TagRepository.getInstance().delete(tag);
@@ -109,35 +107,35 @@ public class BoardRepository implements Repository<Board> {
     }
 
     public void addColumnId(String boardId, String columnId) {
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().BOARDS, boardId, "columnsIds", columnId);
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.BOARDS, boardId, "columnsIds", columnId);
     }
 
     public void updateColumnsIds(String boardId, ArrayList<String> columnsIds) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().BOARDS, boardId, "columnsIds", columnsIds);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.BOARDS, boardId, "columnsIds", columnsIds);
     }
 
     public void updateName(String boardId, String name) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().BOARDS, boardId, "name", name);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.BOARDS, boardId, "name", name);
     }
 
     public void updateDescription(String boardId, String description) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().BOARDS, boardId, "description", description);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.BOARDS, boardId, "description", description);
     }
 
     public void updateRepositoryName(String boardId, String repositoryName) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().BOARDS, boardId, "repositoryName", repositoryName);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.BOARDS, boardId, "repositoryName", repositoryName);
     }
 
     public void addContributor(String boardId, Contributor contributor) {
         ContributorMap contributorMap = new ContributorMap(contributor.getId(), contributor.getRole());
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().BOARDS, boardId, "contributors", contributorMap.getMap());
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.BOARDS, boardId, "contributors", contributorMap.getMap());
     }
 
     public Contributor getContributor(String contributorId) {
 
         Contributor contributor = null;
         UserDocument document;
-        document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().USERS, contributorId)).toObject(UserDocument.class);
+        document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.USERS, contributorId).toObject(UserDocument.class);
 
         if (document != null) {
             contributor = new ContributorBuilder().with($ -> {
@@ -151,13 +149,13 @@ public class BoardRepository implements Repository<Board> {
         return contributor;
     }
 
-    public void updateContributorsIds(String boardId, ArrayList<HashMap<String,String>> contributorsIds){
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().BOARDS, boardId, "contributors", contributorsIds);
+    public void updateContributorsIds(String boardId, ArrayList<HashMap<String, String>> contributorsIds) {
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.BOARDS, boardId, "contributors", contributorsIds);
     }
 
     public void deleteContributor(Board board, Contributor contributor) {
         ContributorMap contributorMap = new ContributorMap(contributor.getId(), contributor.getRole());
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().BOARDS, board.getId(), "contributors", contributorMap.getMap());
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.BOARDS, board.getId(), "contributors", contributorMap.getMap());
 
         for (Column column : board.<Column>getChildren()) {
             for (Task task : column.<Task>getChildren()) {
@@ -172,11 +170,11 @@ public class BoardRepository implements Repository<Board> {
     }
 
     public void addTagId(String boardId, String tagId) {
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().BOARDS, boardId, "tagsIds", tagId);
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.BOARDS, boardId, "tagsIds", tagId);
     }
 
     public void deleteTag(Board board, String tagId) {
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().BOARDS, board.getId(), "tagsIds", tagId);
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.BOARDS, board.getId(), "tagsIds", tagId);
 
         for (Column column : board.<Column>getChildren()) {
             for (Task task : column.<Task>getChildren()) {
@@ -197,7 +195,7 @@ public class BoardRepository implements Repository<Board> {
      * @param columnId Column's id to Delete.
      */
     public void deleteColumnId(String boardId, String columnId) {
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().BOARDS, boardId, "columnsIds", columnId);
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.BOARDS, boardId, "columnsIds", columnId);
     }
 
 }

--- a/src/octillect/database/repositories/ColumnRepository.java
+++ b/src/octillect/database/repositories/ColumnRepository.java
@@ -1,7 +1,5 @@
 package octillect.database.repositories;
 
-import com.google.cloud.firestore.DocumentSnapshot;
-
 import java.util.ArrayList;
 
 import javafx.collections.FXCollections;
@@ -36,13 +34,13 @@ public class ColumnRepository implements Repository<Column> {
         }
         document.setTasksIds(tasksIds);
 
-        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.getInstance().COLUMNS, document.getId(), document);
+        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.COLUMNS, document.getId(), document);
     }
 
     @Override
     public Column get(String columnId) {
 
-        ColumnDocument document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().COLUMNS, columnId)).toObject(ColumnDocument.class);
+        ColumnDocument document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.COLUMNS, columnId).toObject(ColumnDocument.class);
 
         Column column = new ColumnBuilder().with($ -> {
             $.id = document.getId();
@@ -66,22 +64,22 @@ public class ColumnRepository implements Repository<Column> {
      */
     @Override
     public void delete(Column column) {
-        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().COLUMNS, column.getId());
+        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.COLUMNS, column.getId());
         for (Task task : column.<Task>getChildren()) {
             TaskRepository.getInstance().delete(task);
         }
     }
 
     public void addTask(String columnId, String taskId) {
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().COLUMNS, columnId, "tasksIds", taskId);
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.COLUMNS, columnId, "tasksIds", taskId);
     }
 
     public void updateName(String columnId, String name) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().COLUMNS, columnId, "name", name);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.COLUMNS, columnId, "name", name);
     }
 
     public void updateTasksIds(String columnId, ArrayList<String> tasksIds) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().COLUMNS, columnId, "tasksIds", tasksIds);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.COLUMNS, columnId, "tasksIds", tasksIds);
     }
 
     /**
@@ -91,7 +89,7 @@ public class ColumnRepository implements Repository<Column> {
      * @param taskId   Task's id to Delete.
      */
     public void deleteTaskId(String columnId, String taskId) {
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().COLUMNS, columnId, "tasksIds", taskId);
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.COLUMNS, columnId, "tasksIds", taskId);
     }
 
 }

--- a/src/octillect/database/repositories/TagRepository.java
+++ b/src/octillect/database/repositories/TagRepository.java
@@ -1,7 +1,5 @@
 package octillect.database.repositories;
 
-import com.google.cloud.firestore.DocumentSnapshot;
-
 import javafx.scene.paint.Color;
 
 import octillect.database.documents.TagDocument;
@@ -27,13 +25,13 @@ public class TagRepository implements Repository<Tag> {
         document.setId(tag.getId());
         document.setName(tag.getName());
         document.setColor(tag.getColorHex());
-        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.getInstance().TAGS, document.getId(), document);
+        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.TAGS, document.getId(), document);
     }
 
     @Override
     public Tag get(String tagId) {
 
-        TagDocument document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().TAGS, tagId)).toObject(TagDocument.class);
+        TagDocument document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.TAGS, tagId).toObject(TagDocument.class);
 
         Tag tag = new TagBuilder().with($ -> {
             $.id = document.getId();
@@ -46,7 +44,7 @@ public class TagRepository implements Repository<Tag> {
 
     @Override
     public void delete(Tag tag) {
-        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().TAGS, tag.getId());
+        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.TAGS, tag.getId());
     }
 
 }

--- a/src/octillect/database/repositories/TaskRepository.java
+++ b/src/octillect/database/repositories/TaskRepository.java
@@ -1,7 +1,5 @@
 package octillect.database.repositories;
 
-import com.google.cloud.firestore.DocumentSnapshot;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -56,13 +54,13 @@ public class TaskRepository implements Repository<Task> {
         }
         document.setTagsIds(tagsIds);
 
-        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.getInstance().TASKS, document.getId(), document);
+        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.TASKS, document.getId(), document);
     }
 
     @Override
     public Task get(String taskId) {
 
-        TaskDocument document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().TASKS, taskId)).toObject(TaskDocument.class);
+        TaskDocument document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.TASKS, taskId).toObject(TaskDocument.class);
 
         Task task = new TaskBuilder().with($ -> {
             $.id = document.getId();
@@ -104,61 +102,61 @@ public class TaskRepository implements Repository<Task> {
 
     @Override
     public void delete(Task task) {
-        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().TASKS, task.getId());
+        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.TASKS, task.getId());
     }
 
     public void updateName(String taskId, String name) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "name", name);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "name", name);
     }
 
     public void updateDescription(String taskId, String description) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "description", description);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "description", description);
     }
 
     public void updateIsCompleted(String taskId, boolean isCompleted) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "isCompleted", isCompleted);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "isCompleted", isCompleted);
     }
 
     public void updateDueDate(String taskId, Date dueDate) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "dueDate", dueDate);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "dueDate", dueDate);
     }
 
     public void addTagId(String taskId, String tagId) {
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().TASKS, taskId, "tagsIds", tagId);
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.TASKS, taskId, "tagsIds", tagId);
     }
 
     public void updateTagsIds(String taskId, ArrayList<String> tagsIds) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "tagsIds", tagsIds);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "tagsIds", tagsIds);
     }
 
     public void deleteTagId(String taskId, String tagId) {
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().TASKS, taskId, "tagsIds", tagId);
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.TASKS, taskId, "tagsIds", tagId);
     }
 
     public void addAssigneeId(String taskId, String assigneeId) {
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().TASKS, taskId, "assigneesIds", assigneeId);
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.TASKS, taskId, "assigneesIds", assigneeId);
     }
 
     public void updateAssigneesIds(String taskId, ArrayList<String> assigneeIds) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "assigneesIds", assigneeIds);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "assigneesIds", assigneeIds);
     }
 
     public void deleteAssigneeId(String taskId, String assigneeId) {
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().TASKS, taskId, "assigneesIds", assigneeId);
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.TASKS, taskId, "assigneesIds", assigneeId);
     }
 
     public void addSubTask(String parentTaskId, Task subTask) {
         SubTaskMap subTaskMap = new SubTaskMap(subTask.getId(), subTask.getName(), subTask.getIsCompleted());
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().TASKS, parentTaskId, "subTasks", subTaskMap.getMap());
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.TASKS, parentTaskId, "subTasks", subTaskMap.getMap());
     }
 
     public void deleteSubTask(String parentTaskId, Task subTask) {
         SubTaskMap subTaskMap = new SubTaskMap(subTask.getId(), subTask.getName(), subTask.getIsCompleted());
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().TASKS, parentTaskId, "subTasks", subTaskMap.getMap());
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.TASKS, parentTaskId, "subTasks", subTaskMap.getMap());
     }
 
     public void updateCreatorId(String taskId, String userId) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().TASKS, taskId, "creatorId", userId);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.TASKS, taskId, "creatorId", userId);
     }
 
 }

--- a/src/octillect/database/repositories/UserRepository.java
+++ b/src/octillect/database/repositories/UserRepository.java
@@ -1,6 +1,5 @@
 package octillect.database.repositories;
 
-import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -55,7 +54,7 @@ public class UserRepository implements Repository<User> {
         boardsIds.add(user.getBoards().get(0).getId());
         document.setBoardsIds(boardsIds);
 
-        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.getInstance().USERS, document.getId(), document);
+        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.USERS, document.getId(), document);
         setImage(document.getId(), SwingFXUtils.fromFXImage(user.getImage(), null));
 
         BoardRepository.getInstance().add(user.getBoards().get(0));
@@ -72,7 +71,7 @@ public class UserRepository implements Repository<User> {
 
         User user = null;
         UserDocument document;
-        document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().USERS, userId)).toObject(UserDocument.class);
+        document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.USERS, userId).toObject(UserDocument.class);
 
         if (document != null) {
 
@@ -102,14 +101,13 @@ public class UserRepository implements Repository<User> {
 
     public boolean isUserFound(String email) {
         String id = FirestoreAPI.getInstance().encrypt(email);
-        UserDocument document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().USERS, id)).toObject(UserDocument.class);
-        return document != null;
+        return FirestoreAPI.getInstance().selectDocument(FirestoreAPI.USERS, id).exists();
     }
 
     public boolean authenticate(String email, String password) {
         String id = FirestoreAPI.getInstance().encrypt(email);
         String encryptedPassword = FirestoreAPI.getInstance().encrypt(password);
-        UserDocument document = ((DocumentSnapshot) FirestoreAPI.getInstance().selectDocument(FirestoreAPI.getInstance().USERS, id)).toObject(UserDocument.class);
+        UserDocument document = FirestoreAPI.getInstance().selectDocument(FirestoreAPI.USERS, id).toObject(UserDocument.class);
         if (document != null) {
             return document.getPassword().equals(encryptedPassword);
         } else {
@@ -119,22 +117,22 @@ public class UserRepository implements Repository<User> {
 
     // add user's image to CloudStorage
     public void setImage(String userId, BufferedImage userBufferedImage) {
-        StorageAPI.getInstance().uploadImage(userBufferedImage, StorageAPI.getInstance().USER_PHOTOS_FOLDER, userId);
+        StorageAPI.getInstance().uploadImage(userBufferedImage, StorageAPI.USER_PHOTOS_FOLDER, userId);
     }
 
     // Get user's image by userId
     public Image getImage(String userId) {
-        return StorageAPI.getInstance().selectImage(StorageAPI.getInstance().USER_PHOTOS_FOLDER, userId);
+        return StorageAPI.getInstance().selectImage(StorageAPI.USER_PHOTOS_FOLDER, userId);
     }
 
     // Assign board to a specific contributor
     public void addBoardId(String userId, String boardId) {
-        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.getInstance().USERS, userId, "boardsIds", boardId);
+        FirestoreAPI.getInstance().appendArrayElement(FirestoreAPI.USERS, userId, "boardsIds", boardId);
     }
 
     // Deletes boardId from User's boardsIds Field
     public void deleteBoardId(String userId, String boardId) {
-        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.getInstance().USERS, userId, "boardsIds", boardId);
+        FirestoreAPI.getInstance().deleteArrayElement(FirestoreAPI.USERS, userId, "boardsIds", boardId);
     }
 
     /**
@@ -144,7 +142,7 @@ public class UserRepository implements Repository<User> {
      * @param name   Updated Name.
      */
     public void updateName(String userId, String name) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().USERS, userId, "name", name);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.USERS, userId, "name", name);
     }
 
     /**
@@ -158,8 +156,8 @@ public class UserRepository implements Repository<User> {
         // Update all instances of user's id in all Database
         updateId(user, newEmail);
 
-        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.getInstance().USERS, user.getId());
-        StorageAPI.getInstance().deleteImage(StorageAPI.getInstance().USER_PHOTOS_FOLDER, user.getId());
+        FirestoreAPI.getInstance().deleteDocument(FirestoreAPI.USERS, user.getId());
+        StorageAPI.getInstance().deleteImage(StorageAPI.USER_PHOTOS_FOLDER, user.getId());
 
         UserDocument document = new UserDocument();
         document.setId(FirestoreAPI.getInstance().encrypt(newEmail));
@@ -171,7 +169,7 @@ public class UserRepository implements Repository<User> {
         user.getBoards().forEach(board -> boardsIds.add(board.getId()));
         document.setBoardsIds(boardsIds);
 
-        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.getInstance().USERS, document.getId(), document);
+        FirestoreAPI.getInstance().insertDocument(FirestoreAPI.USERS, document.getId(), document);
         setImage(document.getId(), generateIdenticon(document.getId(),256));
     }
 
@@ -227,7 +225,7 @@ public class UserRepository implements Repository<User> {
      * @param encryptedPassword Updated password after encryption.
      */
     public void updatePassword(String userId, String encryptedPassword) {
-        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.getInstance().USERS, userId, "password", encryptedPassword);
+        FirestoreAPI.getInstance().updateAttribute(FirestoreAPI.USERS, userId, "password", encryptedPassword);
     }
 
     /**


### PR DESCRIPTION
 * Make FirebaseAPI & StorageAPI fields static for shorter calls.
 * Change FirebaseAPI's selectDocument method signature; returns a `DocumentSnapshot` instead of `Object`.