### PR TITLE
Fix & Improve OCTException

### DIFF
--- a/src/octillect/exceptions/ErrorView.fxml
+++ b/src/octillect/exceptions/ErrorView.fxml
@@ -10,13 +10,13 @@
 
 <VBox xmlns="http://javafx.com/javafx/"
       xmlns:fx="http://javafx.com/fxml/"
-      fx:id="errorStackPane"
+      fx:id="errorRootVBox"
       stylesheets="@/octillect/styles/Palette.css"
       alignment="CENTER"
       spacing="16"
       style="-fx-background-color: -o-dark-900;
-        -fx-background-image: url(stars-1264x768.png);
-        -fx-background-size: cover;">
+             -fx-background-image: url(stars-1264x768.png);
+             -fx-background-size: cover;">
 
     <fx:define>
         <Palette fx:id="Palette"/>

--- a/src/octillect/exceptions/IRetryStrategy.java
+++ b/src/octillect/exceptions/IRetryStrategy.java
@@ -1,0 +1,10 @@
+package octillect.exceptions;
+
+@FunctionalInterface
+public interface IRetryStrategy {
+    /**
+     * The retrying Strategy for the retry button.
+     * @return true if success and false if fails.
+     */
+    boolean retry();
+}

--- a/src/octillect/exceptions/OCTException.java
+++ b/src/octillect/exceptions/OCTException.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 
 public class OCTException extends Exception {
 
@@ -13,33 +14,33 @@ public class OCTException extends Exception {
     private String errorDescription;
 
     // FXML Fields
-    @FXML private StackPane errorStackPane;
-    @FXML public Label errorLabel;
-    @FXML public Button goBackButton;
-
+    @FXML private VBox errorRootVBox;
+    @FXML private Label errorLabel;
+    @FXML private Button goBackButton;
 
     public OCTException(String errorCode, String errorDescription) {
         this.errorCode        = errorCode;
         this.errorDescription = errorDescription;
     }
 
-    public void dislpayError(StackPane root) {
-
+    public void displayErrorView(StackPane root, IRetryStrategy retryStrategy) {
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("/octillect/exceptions/ErrorView.fxml"));
             fxmlLoader.setController(this);
-            errorStackPane = fxmlLoader.load();
+            errorRootVBox = fxmlLoader.load();
         } catch (Exception e) {
             e.printStackTrace();
         }
         errorLabel.setText("[" + errorCode + "]: " + errorDescription);
         goBackButton.setOnAction(event -> {
-            /*TODO: Add retry method here*/
+            if (retryStrategy.retry()) {
+                root.getChildren().remove(errorRootVBox);
+            }
         });
-        root.getChildren().add(errorStackPane);
+        root.getChildren().add(errorRootVBox);
     }
 
     public void printError() {
-        System.out.println("[" + errorCode + "]: " + errorDescription);
+        System.err.println("[" + errorCode + "]: " + errorDescription);
     }
 }


### PR DESCRIPTION
 * Rename displayError method to displayErrorView.
 * Add IRetryStrategy functional interface.
 * Add IRetryStrategy parameter to displayErrorView method.
 * Fix loading FXML failure.
 * Use System.err instead of System.out for printing errors.